### PR TITLE
Fixed double quote handling in training phrases

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func buildDigitalBot(projectId, lang, flowName, keyPath string) {
 					for _, part := range trainingPhrase.Parts {
 						// escape quotes if they are in the text
 						if strings.Contains(part.Text, "\"") {
-							part.Text = strings.ReplaceAll(part.Text, "\"", "\\")
+							part.Text = strings.ReplaceAll(part.Text, "\"", "\\\"")
 						}
 						// add text to segment
 						segment += fmt.Sprintf("                - text: \"%s\"\n", part.Text)


### PR DESCRIPTION
Now when there is a " in training phrases it gets changed to \" in YAML.